### PR TITLE
Update pear_exception dependency to a stable release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": ">5.2",
-        "pear/pear_exception": "1.0-beta1"
+        "pear/pear_exception": "1.0.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
There's been a stable release of pear/pear_exception out for a while now, and composer prefers stable releases.