### PR TITLE
Homepage is defined twice in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "log",
         "logging"
     ],
-    "homepage": "https://github.com/pear/Log",
     "license": "MIT",
     "require": {
         "php": ">5.2",


### PR DESCRIPTION
Current composer.json defines the key `homepage` twice. Depending on the JSON implementation used to parse this file, either the first or the second homepage link wins. imho, there should only be one homepage in the composer.json file.