### PR TITLE
Deprecate php-4-style constructors

### DIFF
--- a/Log.php
+++ b/Log.php
@@ -111,6 +111,10 @@ class Log
                             '%{class}'      => '%8$s',
                             '%\{'           => '%%{');
 
+    public function __construct()
+    {
+    }
+
     /**
      * Attempts to return a concrete Log instance of type $handler.
      *

--- a/Log/composite.php
+++ b/Log/composite.php
@@ -49,23 +49,6 @@ class Log_composite extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string    $name       This parameter is ignored.
-     * @param string    $ident      This parameter is ignored.
-     * @param array     $conf       This parameter is ignored.
-     * @param int       $level      This parameter is ignored.
-     *
-     * @access public
-     * @deprecated
-     */
-    function Log_composite($name, $ident = '', $conf = array(),
-                           $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Opens all of the child instances.
      *
      * @return  True if all of the child instances were successfully opened.

--- a/Log/composite.php
+++ b/Log/composite.php
@@ -35,17 +35,34 @@ class Log_composite extends Log
     /**
      * Constructs a new composite Log object.
      *
-     * @param boolean   $name       This parameter is ignored.
-     * @param boolean   $ident      This parameter is ignored.
-     * @param boolean   $conf       This parameter is ignored.
-     * @param boolean   $level      This parameter is ignored.
+     * @param string   $name       This parameter is ignored.
+     * @param string   $ident      This parameter is ignored.
+     * @param array    $conf       This parameter is ignored.
+     * @param int      $level      This parameter is ignored.
      *
      * @access public
+     */
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
+    {
+        $this->_ident = $ident;
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string    $name       This parameter is ignored.
+     * @param string    $ident      This parameter is ignored.
+     * @param array     $conf       This parameter is ignored.
+     * @param int       $level      This parameter is ignored.
+     *
+     * @access public
+     * @deprecated
      */
     function Log_composite($name, $ident = '', $conf = array(),
                            $level = PEAR_LOG_DEBUG)
     {
-        $this->_ident = $ident;
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/console.php
+++ b/Log/console.php
@@ -64,15 +64,15 @@ class Log_console extends Log
 
     /**
      * Constructs a new Log_console object.
-     * 
+     *
      * @param string $name     Ignored.
      * @param string $ident    The identity string.
      * @param array  $conf     The configuration array.
      * @param int    $level    Log messages up to and including this level.
      * @access public
      */
-    function Log_console($name, $ident = '', $conf = array(),
-                         $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_ident = $ident;
@@ -108,6 +108,22 @@ class Log_console extends Log
         if ($this->_buffering) {
             register_shutdown_function(array(&$this, '_Log_console'));
         }
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     * 
+     * @param string $name     Ignored.
+     * @param string $ident    The identity string.
+     * @param array  $conf     The configuration array.
+     * @param int    $level    Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_console($name, $ident = '', $conf = array(),
+                         $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/console.php
+++ b/Log/console.php
@@ -111,22 +111,6 @@ class Log_console extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     * 
-     * @param string $name     Ignored.
-     * @param string $ident    The identity string.
-     * @param array  $conf     The configuration array.
-     * @param int    $level    Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_console($name, $ident = '', $conf = array(),
-                         $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Destructor
      */
     function _Log_console()

--- a/Log/daemon.php
+++ b/Log/daemon.php
@@ -104,22 +104,6 @@ class Log_daemon extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name  The syslog facility.
-     * @param string $ident The identity string.
-     * @param array  $conf  The configuration array.
-     * @param int    $level Maximum level at which to log.
-     * @access public
-     * @deprecated
-     */
-    function Log_daemon($name, $ident = '', $conf = array(),
-                        $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Destructor.
      *
      * @access private

--- a/Log/daemon.php
+++ b/Log/daemon.php
@@ -61,18 +61,17 @@ class Log_daemon extends Log
      */
     var $_timeout = 1;
 
-
     /**
      * Constructs a new syslog object.
      *
-     * @param string $name     The syslog facility.
-     * @param string $ident    The identity string.
-     * @param array  $conf     The configuration array.
-     * @param int    $maxLevel Maximum level at which to log.
+     * @param string $name  The syslog facility.
+     * @param string $ident The identity string.
+     * @param array  $conf  The configuration array.
+     * @param int    $level Maximum level at which to log.
      * @access public
      */
-    function Log_daemon($name, $ident = '', $conf = array(),
-                        $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         /* Ensure we have a valid integer value for $name. */
         if (empty($name) || !is_int($name)) {
@@ -102,6 +101,22 @@ class Log_daemon extends Log
         $this->_proto = $this->_proto . '://';
 
         register_shutdown_function(array(&$this, '_Log_daemon'));
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name  The syslog facility.
+     * @param string $ident The identity string.
+     * @param array  $conf  The configuration array.
+     * @param int    $level Maximum level at which to log.
+     * @access public
+     * @deprecated
+     */
+    function Log_daemon($name, $ident = '', $conf = array(),
+                        $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/display.php
+++ b/Log/display.php
@@ -55,8 +55,8 @@ class Log_display extends Log
      * @param int    $level    Log messages up to and including this level.
      * @access public
      */
-    function Log_display($name = '', $ident = '', $conf = array(),
-                         $level = PEAR_LOG_DEBUG)
+    public function __construct($name = '', $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_ident = $ident;
@@ -107,6 +107,22 @@ class Log_display extends Log
         if (isset($conf['rawText'])) {
             $this->_rawText = $conf['rawText'];
         }
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name     Ignored.
+     * @param string $ident    The identity string.
+     * @param array  $conf     The configuration array.
+     * @param int    $level    Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_display($name = '', $ident = '', $conf = array(),
+                         $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/display.php
+++ b/Log/display.php
@@ -110,22 +110,6 @@ class Log_display extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name     Ignored.
-     * @param string $ident    The identity string.
-     * @param array  $conf     The configuration array.
-     * @param int    $level    Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_display($name = '', $ident = '', $conf = array(),
-                         $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Opens the display handler.
      *
      * @access  public

--- a/Log/error_log.php
+++ b/Log/error_log.php
@@ -65,8 +65,8 @@ class Log_error_log extends Log
      * @param int    $level    Log messages up to and including this level.
      * @access public
      */
-    function Log_error_log($name, $ident = '', $conf = array(),
-                           $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_type = $name;
@@ -90,6 +90,22 @@ class Log_error_log extends Log
         if (!empty($conf['timeFormat'])) {
             $this->_timeFormat = $conf['timeFormat'];
         }
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name     One of the PEAR_LOG_TYPE_* constants.
+     * @param string $ident    The identity string.
+     * @param array  $conf     The configuration array.
+     * @param int    $level    Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_error_log($name, $ident = '', $conf = array(),
+                           $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/error_log.php
+++ b/Log/error_log.php
@@ -93,22 +93,6 @@ class Log_error_log extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name     One of the PEAR_LOG_TYPE_* constants.
-     * @param string $ident    The identity string.
-     * @param array  $conf     The configuration array.
-     * @param int    $level    Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_error_log($name, $ident = '', $conf = array(),
-                           $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Opens the handler.
      *
      * @access  public

--- a/Log/file.php
+++ b/Log/file.php
@@ -95,8 +95,8 @@ class Log_file extends Log
      * @param int    $level    Log messages up to and including this level.
      * @access public
      */
-    function Log_file($name, $ident = '', $conf = array(),
-                      $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_filename = $name;
@@ -144,6 +144,22 @@ class Log_file extends Log
         }
 
         register_shutdown_function(array(&$this, '_Log_file'));
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name     Ignored.
+     * @param string $ident    The identity string.
+     * @param array  $conf     The configuration array.
+     * @param int    $level    Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_file($name, $ident = '', $conf = array(),
+                      $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/file.php
+++ b/Log/file.php
@@ -147,22 +147,6 @@ class Log_file extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name     Ignored.
-     * @param string $ident    The identity string.
-     * @param array  $conf     The configuration array.
-     * @param int    $level    Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_file($name, $ident = '', $conf = array(),
-                      $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Destructor
      */
     function _Log_file()

--- a/Log/firebug.php
+++ b/Log/firebug.php
@@ -104,22 +104,6 @@ class Log_firebug extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name     Ignored.
-     * @param string $ident    The identity string.
-     * @param array  $conf     The configuration array.
-     * @param int    $level    Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_firebug($name = '', $ident = 'PHP', $conf = array(),
-                         $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Opens the firebug handler.
      *
      * @access  public

--- a/Log/firebug.php
+++ b/Log/firebug.php
@@ -78,8 +78,8 @@ class Log_firebug extends Log
      * @param int    $level    Log messages up to and including this level.
      * @access public
      */
-    function Log_firebug($name = '', $ident = 'PHP', $conf = array(),
-                         $level = PEAR_LOG_DEBUG)
+    public function __construct($name = '', $ident = 'PHP', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_ident = $ident;
@@ -101,6 +101,22 @@ class Log_firebug extends Log
         if (!empty($conf['timeFormat'])) {
             $this->_timeFormat = $conf['timeFormat'];
         }
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name     Ignored.
+     * @param string $ident    The identity string.
+     * @param array  $conf     The configuration array.
+     * @param int    $level    Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_firebug($name = '', $ident = 'PHP', $conf = array(),
+                         $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/mail.php
+++ b/Log/mail.php
@@ -161,22 +161,6 @@ class Log_mail extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name      The message's recipients.
-     * @param string $ident     The identity string.
-     * @param array  $conf      The configuration array.
-     * @param int    $level     Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_mail($name, $ident = '', $conf = array(),
-                      $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Destructor. Calls close().
      *
      * @access private

--- a/Log/mail.php
+++ b/Log/mail.php
@@ -116,8 +116,8 @@ class Log_mail extends Log
      * @param int    $level     Log messages up to and including this level.
      * @access public
      */
-    function Log_mail($name, $ident = '', $conf = array(),
-                      $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_recipients = $name;
@@ -158,6 +158,22 @@ class Log_mail extends Log
 
         /* register the destructor */
         register_shutdown_function(array(&$this, '_Log_mail'));
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name      The message's recipients.
+     * @param string $ident     The identity string.
+     * @param array  $conf      The configuration array.
+     * @param int    $level     Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_mail($name, $ident = '', $conf = array(),
+                      $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/mcal.php
+++ b/Log/mcal.php
@@ -84,22 +84,6 @@ class Log_mcal extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name     The category to use for our events.
-     * @param string $ident    The identity string.
-     * @param array  $conf     The configuration array.
-     * @param int    $level    Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_mcal($name, $ident = '', $conf = array(),
-                      $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Opens a calendar stream, if it has not already been
      * opened. This is implicitly called by log(), if necessary.
      * @access public

--- a/Log/mcal.php
+++ b/Log/mcal.php
@@ -61,7 +61,6 @@ class Log_mcal extends Log
      */
     var $_name = LOG_SYSLOG;
 
-
     /**
      * Constructs a new Log_mcal object.
      *
@@ -71,8 +70,8 @@ class Log_mcal extends Log
      * @param int    $level    Log messages up to and including this level.
      * @access public
      */
-    function Log_mcal($name, $ident = '', $conf = array(),
-                      $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_name = $name;
@@ -82,6 +81,22 @@ class Log_mcal extends Log
         $this->_username = $conf['username'];
         $this->_password = $conf['password'];
         $this->_options = $conf['options'];
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name     The category to use for our events.
+     * @param string $ident    The identity string.
+     * @param array  $conf     The configuration array.
+     * @param int    $level    Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_mcal($name, $ident = '', $conf = array(),
+                      $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/mdb2.php
+++ b/Log/mdb2.php
@@ -152,22 +152,6 @@ class Log_mdb2 extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name         The target SQL table.
-     * @param string $ident        The identification field.
-     * @param array $conf          The connection configuration array.
-     * @param int $level           Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_mdb2($name, $ident = '', $conf = array(),
-                      $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Opens a connection to the database, if it has not already
      * been opened. This is implicitly called by log(), if necessary.
      *

--- a/Log/mdb2.php
+++ b/Log/mdb2.php
@@ -112,8 +112,8 @@ class Log_mdb2 extends Log
      * @param int $level           Log messages up to and including this level.
      * @access public
      */
-    function Log_mdb2($name, $ident = '', $conf = array(),
-                     $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_table = $name;
@@ -149,6 +149,22 @@ class Log_mdb2 extends Log
         } else {
             $this->_dsn = $conf['dsn'];
         }
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name         The target SQL table.
+     * @param string $ident        The identification field.
+     * @param array $conf          The connection configuration array.
+     * @param int $level           Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_mdb2($name, $ident = '', $conf = array(),
+                      $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/null.php
+++ b/Log/null.php
@@ -36,22 +36,6 @@ class Log_null extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name     Ignored.
-     * @param string $ident    The identity string.
-     * @param array  $conf     The configuration array.
-     * @param int    $level    Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_null($name, $ident = '', $conf = array(),
-                      $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Opens the handler.
      *
      * @access  public

--- a/Log/null.php
+++ b/Log/null.php
@@ -27,12 +27,28 @@ class Log_null extends Log
      * @param int    $level    Log messages up to and including this level.
      * @access public
      */
-    function Log_null($name, $ident = '', $conf = array(),
-					  $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_ident = $ident;
         $this->_mask = Log::UPTO($level);
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name     Ignored.
+     * @param string $ident    The identity string.
+     * @param array  $conf     The configuration array.
+     * @param int    $level    Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_null($name, $ident = '', $conf = array(),
+                      $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/observer.php
+++ b/Log/observer.php
@@ -47,10 +47,24 @@ class Log_observer
      *
      * @access public
      */
-    function Log_observer($priority = PEAR_LOG_INFO)
+    public function __construct($priority = PEAR_LOG_INFO)
     {
         $this->_id = md5(microtime());
         $this->_priority = $priority;
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param integer   $priority   The highest priority at which to receive
+     *                              log event notifications.
+     *
+     * @access public
+     * @deprecated
+     */
+    function Log_observer($priority = PEAR_LOG_INFO)
+    {
+        self::__construct($priority);
     }
 
     /**

--- a/Log/observer.php
+++ b/Log/observer.php
@@ -54,20 +54,6 @@ class Log_observer
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param integer   $priority   The highest priority at which to receive
-     *                              log event notifications.
-     *
-     * @access public
-     * @deprecated
-     */
-    function Log_observer($priority = PEAR_LOG_INFO)
-    {
-        self::__construct($priority);
-    }
-
-    /**
      * Attempts to return a new concrete Log_observer instance of the requested
      * type.
      *

--- a/Log/sql.php
+++ b/Log/sql.php
@@ -107,7 +107,6 @@ class Log_sql extends Log
      */
     var $_identLimit = 16;
 
-
     /**
      * Constructs a new sql logging object.
      *
@@ -117,8 +116,8 @@ class Log_sql extends Log
      * @param int $level           Log messages up to and including this level.
      * @access public
      */
-    function Log_sql($name, $ident = '', $conf = array(),
-                     $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_table = $name;
@@ -159,6 +158,22 @@ class Log_sql extends Log
         } else {
             $this->_dsn = $conf['dsn'];
         }
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name         The target SQL table.
+     * @param string $ident        The identification field.
+     * @param array $conf          The connection configuration array.
+     * @param int $level           Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_sql($name, $ident = '', $conf = array(),
+                     $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/sql.php
+++ b/Log/sql.php
@@ -161,22 +161,6 @@ class Log_sql extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name         The target SQL table.
-     * @param string $ident        The identification field.
-     * @param array $conf          The connection configuration array.
-     * @param int $level           Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_sql($name, $ident = '', $conf = array(),
-                     $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Opens a connection to the database, if it has not already
      * been opened. This is implicitly called by log(), if necessary.
      *

--- a/Log/sqlite.php
+++ b/Log/sqlite.php
@@ -89,23 +89,6 @@ class Log_sqlite extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name         The target SQL table.
-     * @param string $ident        The identification field.
-     * @param mixed  $conf         Can be an array of configuration options used
-     *                             to open a new database connection
-     *                             or an already opened sqlite connection.
-     * @param int    $level        Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_sqlite($name, $ident = '', &$conf, $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Opens a connection to the database, if it has not already
      * been opened. This is implicitly called by log(), if necessary.
      *

--- a/Log/sqlite.php
+++ b/Log/sqlite.php
@@ -59,7 +59,6 @@ class Log_sqlite extends Log
      */
     var $_table = 'log_table';
 
-
     /**
      * Constructs a new sql logging object.
      *
@@ -71,7 +70,7 @@ class Log_sqlite extends Log
      * @param int    $level        Log messages up to and including this level.
      * @access public
      */
-    function Log_sqlite($name, $ident = '', &$conf, $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', &$conf, $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_table = $name;
@@ -87,6 +86,23 @@ class Log_sqlite extends Log
             $this->_db =& $conf;
             $this->_existingConnection = true;
         }
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name         The target SQL table.
+     * @param string $ident        The identification field.
+     * @param mixed  $conf         Can be an array of configuration options used
+     *                             to open a new database connection
+     *                             or an already opened sqlite connection.
+     * @param int    $level        Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_sqlite($name, $ident = '', &$conf, $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/syslog.php
+++ b/Log/syslog.php
@@ -78,8 +78,8 @@ class Log_syslog extends Log
      * @param int    $level    Log messages up to and including this level.
      * @access public
      */
-    function Log_syslog($name, $ident = '', $conf = array(),
-                        $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         /* Ensure we have a valid integer value for $name. */
         if (empty($name) || !is_int($name)) {
@@ -109,6 +109,22 @@ class Log_syslog extends Log
         $this->_name = $name;
         $this->_ident = $ident;
         $this->_mask = Log::UPTO($level);
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name     The syslog facility.
+     * @param string $ident    The identity string.
+     * @param array  $conf     The configuration array.
+     * @param int    $level    Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_syslog($name, $ident = '', $conf = array(),
+                        $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/syslog.php
+++ b/Log/syslog.php
@@ -112,22 +112,6 @@ class Log_syslog extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name     The syslog facility.
-     * @param string $ident    The identity string.
-     * @param array  $conf     The configuration array.
-     * @param int    $level    Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_syslog($name, $ident = '', $conf = array(),
-                        $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Opens a connection to the system logger, if it has not already
      * been opened.  This is implicitly called by log(), if necessary.
      * @access public

--- a/Log/win.php
+++ b/Log/win.php
@@ -69,8 +69,8 @@ class Log_win extends Log
      * @param int    $level    Log messages up to and including this level.
      * @access public
      */
-    function Log_win($name, $ident = '', $conf = array(),
-                          $level = PEAR_LOG_DEBUG)
+    public function __construct($name, $ident = '', $conf = array(),
+                                $level = PEAR_LOG_DEBUG)
     {
         $this->_id = md5(microtime());
         $this->_name = str_replace(' ', '_', $name);
@@ -90,6 +90,22 @@ class Log_win extends Log
         }
 
         register_shutdown_function(array(&$this, '_Log_win'));
+    }
+
+    /**
+     * Legacy constructor, to be removed in a future release.
+     *
+     * @param string $name     Ignored.
+     * @param string $ident    The identity string.
+     * @param array  $conf     The configuration array.
+     * @param int    $level    Log messages up to and including this level.
+     * @access public
+     * @deprecated
+     */
+    function Log_win($name, $ident = '', $conf = array(),
+                          $level = PEAR_LOG_DEBUG)
+    {
+        self::__construct($name, $ident, $conf, $level);
     }
 
     /**

--- a/Log/win.php
+++ b/Log/win.php
@@ -93,22 +93,6 @@ class Log_win extends Log
     }
 
     /**
-     * Legacy constructor, to be removed in a future release.
-     *
-     * @param string $name     Ignored.
-     * @param string $ident    The identity string.
-     * @param array  $conf     The configuration array.
-     * @param int    $level    Log messages up to and including this level.
-     * @access public
-     * @deprecated
-     */
-    function Log_win($name, $ident = '', $conf = array(),
-                          $level = PEAR_LOG_DEBUG)
-    {
-        self::__construct($name, $ident, $conf, $level);
-    }
-
-    /**
      * Destructor
      */
     function _Log_win()


### PR DESCRIPTION
In php 4 the name of the constructor function had to match the class name. php 5 introduced `__construct()` as new constructor function for classes that should be used instead.

Now, php 7 deprecates the php-4-syle constructors. That means, a `E_DEPRECATED` warning is triggered if such a function is still in use. Furthermore, a future php release (probably 7.1) will remove support for those constructor functions.

This PR adds `__construct()` to all classes. Since simply renaming all constructor functions will break code with classes that extend one of the `Log_*` classes, referring to the old constructor, the old constructor is kept in place, simply calling the new one.

I have also added a `__construct()` method to the `Log` class. This might seem a bit odd at first. I did that because php 7 interprets the presence of the `log()` method as old-style constructor (d'oh), so adding a `__construct()` method here avoids an `E_DEPRECATED` warning.