### PR TITLE
Update/Fix CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: php
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,21 @@
+sudo: false
 language: php
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - nightly
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+  include:
+  - php: 5.4
+    dist: trusty
+  - php: 5.5
+    dist: trusty
+  - php: 5.6
+  - php: 7.0
+  - php: 7.1
+  - php: 7.2
+  - php: 7.3
+  - php: 7.4
+  - php: nightly
 install:
   - pear install package.xml
 script: pear run-tests tests/

--- a/tests/composite.phpt
+++ b/tests/composite.phpt
@@ -21,7 +21,8 @@ function printIdents($children) {
 }
 
 function testPriority($composite, $priority) {
-    $name = Log::priorityToString($priority);
+    $log = new Log;
+    $name = $log->priorityToString($priority);
     $success = $composite->log($name, $priority);
     echo "$name : " . (($success) ? 'GOOD' : 'BAD') . "\n";
 }


### PR DESCRIPTION
This updates the CI config in light of changes Travis CI have made to their PHP support on various OSes.

You can see the status of these tests (as a test!) here: 

https://travis-ci.org/github/MikeyMJCO/Log

The PHP nightly build is failing due to `justinrainbow/json-schema` which is, itself failing on nightly: https://travis-ci.org/github/justinrainbow/json-schema