### PR TITLE
Fix test failure on Nightly PHP builds.

### DIFF
--- a/tests/composite.phpt
+++ b/tests/composite.phpt
@@ -21,7 +21,8 @@ function printIdents($children) {
 }
 
 function testPriority($composite, $priority) {
-    $name = Log::priorityToString($priority);
+    $log = new Log;
+    $name = $log->priorityToString($priority);
     $success = $composite->log($name, $priority);
     echo "$name : " . (($success) ? 'GOOD' : 'BAD') . "\n";
 }


### PR DESCRIPTION
This resolves the current test failure on PHP8.0.0-dev (Nightly!) which is:

`Fatal error: Uncaught Error: Non-static method Log::priorityToString() cannot be called statically in tests/composite.php:19`