### PR TITLE
Update Travis-CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ matrix:
   allow_failures:
     - php: nightly
   include:
-  - php: 5.4
+  - php: 5.4.45
     dist: trusty
-  - php: 5.5
+  - php: 5.5.38
     dist: trusty
   - php: 5.6
   - php: 7.0


### PR DESCRIPTION
A small PR to update the Travis-CI config again - Travis appears to have transient issues building from `5.4` and `5.5` but not from `5.4.45` and `5.5.38`.

Results of this PR are shown here:

https://travis-ci.org/github/MikeyMJCO/Log/builds/715427273