### PR TITLE
Fix for 32-bit

### DIFF
--- a/Log.php
+++ b/Log.php
@@ -19,7 +19,7 @@ define('PEAR_LOG_NOTICE',   5);     /* Normal but significant */
 define('PEAR_LOG_INFO',     6);     /* Informational */
 define('PEAR_LOG_DEBUG',    7);     /* Debug-level messages */
 
-define('PEAR_LOG_ALL',      0xffffffff);    /* All messages */
+define('PEAR_LOG_ALL',      0x7fffffff);    /* All messages */
 define('PEAR_LOG_NONE',     0x00000000);    /* No message */
 
 /* Log types for PHP's native error_log() function. */


### PR DESCRIPTION
Else float will be used and and break type hinting

Test suite failing with 
```
Fatal error: Uncaught TypeError: Cannot assign float to property Log::$mask of type int in /builddir/build/BUILDROOT/php-pear-Log-1.14.0-1.fc39.noarch/usr/share/pear/Log.php:147
```
See https://kojipkgs.fedoraproject.org//work/tasks/1602/111561602/build.log