### PR TITLE
Require php >= 7.4 instead of >7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">7.4",
+        "php": ">=7.4",
         "pear/pear_exception": "1.0.1 || 1.0.2"
     },
     "autoload": {


### PR DESCRIPTION
Hi,
I'm wondering if this was an oversight to require `>7.4` instead of `>=7.4` since we see a composer conflict where we have the [minimum set to 7.4.0](https://github.com/civicrm/civicrm-core/blob/1dab49b65026f786abbecd0234ffbfdb0ba5b69a/composer.json#L44)