### PR TITLE
PHP8.4 Fix Implicitly nullable parameter  deprecation

### DIFF
--- a/Log.php
+++ b/Log.php
@@ -237,7 +237,7 @@ class Log
      * Abstract implementation of the log() method.
      * @since Log 1.0
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         return false;
     }

--- a/Log/composite.php
+++ b/Log/composite.php
@@ -129,7 +129,7 @@ class Log_composite extends Log
      *
      * @return boolean  True if the entry is successfully logged.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/console.php
+++ b/Log/console.php
@@ -181,7 +181,7 @@ class Log_console extends Log
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/daemon.php
+++ b/Log/daemon.php
@@ -149,7 +149,7 @@ class Log_daemon extends Log
      *                  LOG_ERR, LOG_WARNING, LOG_NOTICE, LOG_INFO,
      *                  and LOG_DEBUG.  The default is LOG_INFO.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/display.php
+++ b/Log/display.php
@@ -139,7 +139,7 @@ class Log_display extends Log
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/error_log.php
+++ b/Log/error_log.php
@@ -134,7 +134,7 @@ class Log_error_log extends Log
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/file.php
+++ b/Log/file.php
@@ -257,7 +257,7 @@ class Log_file extends Log
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/firebug.php
+++ b/Log/firebug.php
@@ -165,7 +165,7 @@ class Log_firebug extends Log
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/mail.php
+++ b/Log/mail.php
@@ -249,7 +249,7 @@ class Log_mail extends Log
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/mcal.php
+++ b/Log/mcal.php
@@ -116,7 +116,7 @@ class Log_mcal extends Log
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/mdb2.php
+++ b/Log/mdb2.php
@@ -223,7 +223,7 @@ class Log_mdb2 extends Log
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/sql.php
+++ b/Log/sql.php
@@ -217,7 +217,7 @@ class Log_sql extends Log
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/sqlite.php
+++ b/Log/sqlite.php
@@ -150,7 +150,7 @@ class Log_sqlite extends Log
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/syslog.php
+++ b/Log/syslog.php
@@ -151,7 +151,7 @@ class Log_syslog extends Log
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {

--- a/Log/win.php
+++ b/Log/win.php
@@ -238,7 +238,7 @@ EOT;
      *                  PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG.
      * @return boolean  True on success or false on failure.
      */
-    public function log($message, int $priority = null): bool
+    public function log($message, ?int $priority = null): bool
     {
         /* If a priority hasn't been specified, use the default value. */
         if ($priority === null) {


### PR DESCRIPTION
This aims to fix the following php8.4 Deprecation notice

Log::log(): Implicitly marking parameter $priority as nullable is deprecated, the explicit nullable type must be used instead at Log.php:240
Deprecated: Log_file::log(): Implicitly marking parameter $priority as nullable is deprecated, the explicit nullable type must be used instead in Log/file.php on line 260

ping @jparise @eileenmcnaughton @demeritcowboy 