### PR TITLE
Lint PHP files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           php-version: ${{ matrix.php-version }}
           extensions: sqlite
           ini-values: include_path=.:/usr/share/php
-      - name: Run tests
-        run: |
-          pear run-tests -d tests/
+      - name: Lint
+        if: ${{ matrix.php-version != '7.4' }}
+        run: for f in ./**/*.php; do php -l "$f"; done;
+      - name: Tests
+        run: pear run-tests -d tests/


### PR DESCRIPTION
`php -l` didn't handle multiple source file arguments until PHP 8.2 so
we need to use a loop to process everything.

We have an outstanding lint error in Log/sql.php under PHP 7.x ("mixed
property cannot have a default value"). For now, just skip running lint
on that version.